### PR TITLE
Encode without writing

### DIFF
--- a/lib/modboss.ex
+++ b/lib/modboss.ex
@@ -210,7 +210,7 @@ defmodule ModBoss do
     cond do
       Enum.any?(unknown_names) ->
         names = unknown_names |> Enum.map_join(", ", fn name -> inspect(name) end)
-        {:error, "Unknown register(s) #{names} for #{inspect(module)}."}
+        {:error, "Unknown mapping(s) #{names} for #{inspect(module)}."}
 
       mode == :readable and Enum.any?(unreadable(mappings)) ->
         names = unreadable(mappings) |> Enum.map_join(", ", fn %{name: name} -> inspect(name) end)

--- a/lib/modboss/encoding.ex
+++ b/lib/modboss/encoding.ex
@@ -5,7 +5,7 @@ defmodule ModBoss.Encoding do
   To make use of these functions, use the `:as` option in your `ModBoss.Schema` but leave off
   the `encode_` or `decode_` prefix.
 
-  In other words, to use the built-in ASCII translation, specifiy `as: :ascii` in your schema.
+  For example, to use the built-in ASCII translation, specify `as: :ascii` in your schema.
 
   ### Note about that extra arg…
 

--- a/lib/modboss/mapping.ex
+++ b/lib/modboss/mapping.ex
@@ -11,7 +11,7 @@ defmodule ModBoss.Mapping do
           register_count: integer(),
           as: atom() | {module(), atom()},
           value: any(),
-          encoded_value: integer(),
+          encoded_value: integer() | [integer()],
           mode: :r | :rw | :w
         }
 

--- a/test/modboss_test.exs
+++ b/test/modboss_test.exs
@@ -440,7 +440,7 @@ defmodule ModBossTest do
     end
   end
 
-  describe "ModBoss.write/4" do
+  describe "ModBoss.write/3" do
     test "writes registers referenced by human-readable names from map" do
       device = start_supervised!({Agent, fn -> @initial_state end})
       :ok = ModBoss.write(FakeSchema, write_func(device), %{baz: 1, corge: 1234})

--- a/test/modboss_test.exs
+++ b/test/modboss_test.exs
@@ -64,7 +64,7 @@ defmodule ModBossTest do
     test "returns an error if any mapping names are unrecognized" do
       device = start_supervised!({Agent, fn -> @initial_state end})
 
-      assert {:error, "Unknown register(s) :foobar, :bazqux for ModBossTest.FakeSchema."} =
+      assert {:error, "Unknown mapping(s) :foobar, :bazqux for ModBossTest.FakeSchema."} =
                ModBoss.read(FakeSchema, read_func(device), [:foobar, :bazqux])
     end
 
@@ -456,7 +456,7 @@ defmodule ModBossTest do
     test "returns an error if any mapping names are unrecognized" do
       device = start_supervised!({Agent, fn -> @initial_state end})
 
-      assert {:error, "Unknown register(s) :foobar, :bazqux for ModBossTest.FakeSchema."} =
+      assert {:error, "Unknown mapping(s) :foobar, :bazqux for ModBossTest.FakeSchema."} =
                ModBoss.write(FakeSchema, write_func(device), %{foobar: 1, bazqux: 2})
     end
 
@@ -725,7 +725,7 @@ defmodule ModBossTest do
       """)
 
       assert {:error, message} = ModBoss.encode(schema, %{foo: 1, bar: 2, baz: 3})
-      assert String.match?(message, ~r/Unknown register/i)
+      assert String.match?(message, ~r/Unknown mapping/i)
 
       assert {:ok, _encoded_values} = ModBoss.encode(schema, %{foo: 1, bar: 2})
     end


### PR DESCRIPTION
Allow values to be encoded without actually writing them to the Modbus.

This can be useful for testing, etc.